### PR TITLE
Use OnEndRequestCallbacks instead of GlobalResponseFilters

### DIFF
--- a/src/Autofac.Extras.ServiceStack/AutofacLifecycleFilter.cs
+++ b/src/Autofac.Extras.ServiceStack/AutofacLifecycleFilter.cs
@@ -11,10 +11,10 @@ namespace Autofac.Extras.ServiceStack
             appHost.Container.Adapter = new AutofacIocAdapter(container);
 
             appHost.GlobalRequestFilters.Add((req, resp, dto) => CreateScope(container));
-            appHost.GlobalResponseFilters.Add((req, resp, dto) => DisposeScope());
+            appHost.OnEndRequestCallbacks.Add(req => DisposeScope());
 
             appHost.GlobalMessageRequestFilters.Add((req, resp, dto) => CreateScope(container));
-            appHost.GlobalMessageRequestFilters.Add((req, resp, dto) => DisposeScope());
+            appHost.GlobalMessageResponseFilters.Add((req, resp, dto) => DisposeScope());
             
             return appHost;
         }


### PR DESCRIPTION
I propose using `OnEndRequestCallbacks` instead of `GlobalResponseFilters` because:
1) you can have some container dependencies in other response filters
2) if you're using EntityFramework and accidentally return IQueryable as service response, ServiceStack serializes this response *after* `GlobalResponseFilters` are fired. Serialization needs to execute db query to evaluate IQueryable, but container (and in my case database connection) has been disposed. `OnEndRequestCallbacks` are executed at the very end of service processing, after response serialization.

I have also changed `GlobalMessageRequestFilters` to `GlobalMessageResponseFilters` which looks like typo.