### PR TITLE
Change IContainer to ILifetimeScope

### DIFF
--- a/src/Autofac.Extras.ServiceStack/AutofacIocAdapter.cs
+++ b/src/Autofac.Extras.ServiceStack/AutofacIocAdapter.cs
@@ -5,12 +5,12 @@ namespace Autofac.Extras.ServiceStack
 {
     public class AutofacIocAdapter : IContainerAdapter
     {
-        public AutofacIocAdapter(IContainer container)
+        public AutofacIocAdapter(ILifetimeScope container)
         {
             Container = container;
         }
 
-        public IContainer Container { get; }
+        public ILifetimeScope Container { get; }
 
         public T Resolve<T>() 
             => GetCurrentContext().Resolve<T>();

--- a/src/Autofac.Extras.ServiceStack/AutofacLifecycleFilter.cs
+++ b/src/Autofac.Extras.ServiceStack/AutofacLifecycleFilter.cs
@@ -6,7 +6,7 @@ namespace Autofac.Extras.ServiceStack
 {
     public static class ServiceStackAutofac
     {
-        public static ServiceStackHost UseAutofac(this ServiceStackHost appHost, IContainer container)
+        public static ServiceStackHost UseAutofac(this ServiceStackHost appHost, ILifetimeScope container)
         {
             appHost.Container.Adapter = new AutofacIocAdapter(container);
 
@@ -19,7 +19,7 @@ namespace Autofac.Extras.ServiceStack
             return appHost;
         }
 
-        private static void CreateScope(IContainer container)
+        private static void CreateScope(ILifetimeScope container)
         {
             var scope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
             CallContext.LogicalSetData(Consts.AutofacScopeLogicalContextKey, scope);


### PR DESCRIPTION
This change makes testing faster. I have few functional tests which test whole services (without any mocks). About half of my container are singletons, rest of it is created in request scope. My solution is to create container once, and then create lifetime scope for every test case. 
The problem: I can't use `ILifetimeScope` with UseAutofac function.